### PR TITLE
Synced the version of ginkgo between docker image and autoscaler-release

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -3,7 +3,11 @@ name: Create and publish a Docker image
 on:
   push:
     branches: ['master']
+    paths:
+      - 'dockerfiles/**'
   pull_request:
+    paths:
+      - 'dockerfiles/**'
   workflow_dispatch:
 
 env:
@@ -27,35 +31,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Prepare
-        id: prep
-        run: |
-          EVENT_NAME=${{ github.event_name }}
-          IS_FORK=${{ github.event.pull_request.head.repo.fork }}
-
-          echo "Event Name = $EVENT_NAME"
-          echo "Is Fork = $IS_FORK"
-          
-          if [ "$EVENT_NAME" = "push" ]; then
-            echo "::set-output name=should_push::true"
-          elif [ "$EVENT_NAME" = "pull_request" ]; then
-            if [ "$IS_FORK" = "true" ]; then
-              echo "::set-output name=should_push::false"
-            else
-              echo "::set-output name=should_push::true"
-            fi
-          fi
-
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
-        if: github.event_name != 'pull_request'
+        if: ${{ github.event_name != 'pull_request' }}
         uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
         with:
           cosign-release: 'v1.4.0'
 
       - name: Log in to the Container registry
-        if: ${{ steps.prep.outputs.should_push == 'true' }}
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ env.REGISTRY }}
@@ -68,14 +52,23 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.image_suffix }}
 
+      - name: Get ginkgo version from autoscaler-release
+        id: ginkgo
+        run: |
+          version=$(curl https://raw.githubusercontent.com/cloudfoundry/app-autoscaler-release/main/src/autoscaler/go.mod | grep "ginkgo/v2" | cut -d" " -f 2)
+          echo "GINGO version from release: \'${version}\'"
+          echo "::set-output name=version::${version}"  
+
       - name: Build and push
         id: build-and-push
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: dockerfiles/autoscaler-${{ matrix.image_suffix }} 
-          push: ${{ steps.prep.outputs.should_push == 'true' }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.image_suffix }}:latest
+          build-args: GINKGO_VERSION=${{ steps.ginkgo.outputs.version }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/dockerfiles/autoscaler-deploy/Dockerfile
+++ b/dockerfiles/autoscaler-deploy/Dockerfile
@@ -4,19 +4,16 @@ FROM ubuntu:20.04
 MAINTAINER autoscaler-team
 
 RUN apt-get update && \
-      apt-get -qqy install --fix-missing \
-            gnupg \
-	    apt-transport-https \
-            wget
+    apt-get -qqy install --fix-missing gnupg apt-transport-https wget && \
+    apt-get clean
  
 RUN wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add - && \
       echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list && \
       wget -q -O - https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
       echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 
-RUN \
-      apt-get update && \
-      apt-get -qqy install --fix-missing \
+RUN apt-get update && \
+    apt-get -qqy install --fix-missing \
             build-essential \
             inetutils-ping \
             vim \
@@ -33,9 +30,8 @@ RUN \
             python3 \
             ca-certificates \
             cf8-cli \
-            gh \
-      && \
-      apt-get clean
+            gh && \
+    apt-get clean
 
 # Install go
 ENV GO_VERSION 1.18
@@ -48,10 +44,6 @@ RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
 ENV GOPATH /go
 # add go and GOPATH/bin to PATH
 ENV PATH $PATH:$GOPATH/bin:/usr/local/go/bin
-
-# Ginkgo
-RUN go install github.com/onsi/ginkgo/ginkgo@latest && \
-  ginkgo version
 
 # Install bosh_cli
 ENV BOSH_VERSION 6.4.4
@@ -77,8 +69,8 @@ RUN gem install cf-uaac
 # Install jq as a nice to have on container debugging
 ENV JQ_VERSION 1.6
 RUN wget -q https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 && \
-  mv jq-linux64 /usr/local/bin/jq && \
-  chmod +x /usr/local/bin/jq
+    mv jq-linux64 /usr/local/bin/jq && \
+    chmod +x /usr/local/bin/jq
 
 # Install yq
 COPY --from=yq /usr/bin/yq /usr/local/bin/yq
@@ -86,7 +78,11 @@ COPY --from=yq /usr/bin/yq /usr/local/bin/yq
 # Install gcloud
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
   curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
-  apt-get update -y && \
-  apt-get install google-cloud-sdk -y
-      
-RUN gcloud version
+  apt-get update -y &&\
+  apt-get install google-cloud-sdk -y &&\
+  apt-get clean &&\
+  gcloud version
+
+ARG GINKGO_VERSION=v2.1.3
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION} &&\
+    ginkgo version

--- a/dockerfiles/autoscaler-test/Dockerfile
+++ b/dockerfiles/autoscaler-test/Dockerfile
@@ -21,7 +21,8 @@ RUN \
             gnupg \
             gnupg2 \
             ruby \
-            ruby-dev
+            ruby-dev &&\
+    apt-get clean
 
 RUN wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | apt-key add - 
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/postgresql.list 
@@ -64,7 +65,7 @@ RUN gem install cf-uaac
 ENV PGDATA /var/lib/postgresql/${POSTGRES_VERSION}/main
 ENV PGCONFIG /etc/postgresql/${POSTGRES_VERSION}/main
 RUN sed -i 's/peer/trust/' ${PGCONFIG}/pg_hba.conf \
-  	&& sed -i 's/md5/trust/' ${PGCONFIG}/pg_hba.conf 
+  	&& sed -i 's/md5/trust/' ${PGCONFIG}/pg_hba.conf
 
 # Install jq
 ENV JQ_VERSION 1.6


### PR DESCRIPTION
This PR is to enable the reading of the ginkgo version from autoscaler-release  and install it using apt-get. It also cleans the apt-get caches every time to limit the size of the layers